### PR TITLE
feat[KKST-169] wrapper for check rate api

### DIFF
--- a/lib/platform_client/requests.rb
+++ b/lib/platform_client/requests.rb
@@ -87,7 +87,7 @@ module PlatformClient
       # @param check_out_date [String] Check-out date in 'YYYY-MM-DD' format
       # @param adults_count [Integer] Number of adults, default is 1
       #
-      # @return [PlatformClient::Responses::Rates]
+      # @return [PlatformClient::Responses::Rate]
       def check_rate(property_code:, room_code:, check_in_date:, check_out_date:, adults_count: 1)
         Rate.call(property_code:, room_code:, check_in_date:, check_out_date:, adults_count:)
       end

--- a/lib/platform_client/requests.rb
+++ b/lib/platform_client/requests.rb
@@ -9,6 +9,7 @@ require 'platform_client/requests/facilities'
 require 'platform_client/requests/properties'
 require 'platform_client/requests/property_categories'
 require 'platform_client/requests/room_categories'
+require 'platform_client/requests/rate'
 
 module PlatformClient
   # Wrapper over requests
@@ -76,6 +77,19 @@ module PlatformClient
       # @return [PlatformClient::Responses::RoomCategories]
       def room_categories(page: nil, limit: nil)
         RoomCategories.call(page:, limit:)
+      end
+
+      # Check rate for a property room
+      #
+      # @param property_code [String] Property code
+      # @param room_code [String] Room code
+      # @param check_in_date [String] Check-in date in 'YYYY-MM-DD' format
+      # @param check_out_date [String] Check-out date in 'YYYY-MM-DD' format
+      # @param adults_count [Integer] Number of adults, default is 1
+      #
+      # @return [PlatformClient::Responses::Rates]
+      def check_rate(property_code:, room_code:, check_in_date:, check_out_date:, adults_count: 1)
+        Rate.call(property_code:, room_code:, check_in_date:, check_out_date:, adults_count:)
       end
     end
   end

--- a/lib/platform_client/requests/base.rb
+++ b/lib/platform_client/requests/base.rb
@@ -59,7 +59,7 @@ module PlatformClient
       end
 
       def params
-        raise NotImplementedError
+        attributes.compact_blank
       end
 
       def uri_params

--- a/lib/platform_client/requests/end_point.rb
+++ b/lib/platform_client/requests/end_point.rb
@@ -47,6 +47,11 @@ module PlatformClient
           method: :get,
           type: :content,
         },
+        rate: {
+          uri: '/api/check_rate',
+          method: :get,
+          type: :shopping,
+        },
       }.freeze
 
       class << self

--- a/lib/platform_client/requests/rate.rb
+++ b/lib/platform_client/requests/rate.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PlatformClient
+  DEFAULT_LANGUAGE = 'en-US'
+  JAPANESE_LANGUAGE = 'ja-JP'
+  SUPPORTED_LANGUAGES = [DEFAULT_LANGUAGE, JAPANESE_LANGUAGE].freeze
+
+  module Requests
+    # Wrapper for the /api/check_rate endpoint
+    class Rate < Base
+      attribute :property_code, :string
+      attribute :room_code, :string
+      attribute :check_in_date, :string
+      attribute :check_out_date, :string
+      attribute :adults_count, :integer
+
+      validates :property_code, :room_code, presence: true
+      validates :check_in_date, :check_out_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be in YYYY-MM-DD format' }
+      validates :adults_count, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 5 }, allow_nil: true
+
+      private
+
+      def params
+        attributes.compact_blank
+      end
+    end
+  end
+end

--- a/lib/platform_client/requests/rate.rb
+++ b/lib/platform_client/requests/rate.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module PlatformClient
-  DEFAULT_LANGUAGE = 'en-US'
-  JAPANESE_LANGUAGE = 'ja-JP'
-  SUPPORTED_LANGUAGES = [DEFAULT_LANGUAGE, JAPANESE_LANGUAGE].freeze
-
   module Requests
     # Wrapper for the /api/check_rate endpoint
     class Rate < Base
@@ -17,12 +13,6 @@ module PlatformClient
       validates :property_code, :room_code, presence: true
       validates :check_in_date, :check_out_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be in YYYY-MM-DD format' }
       validates :adults_count, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 5 }, allow_nil: true
-
-      private
-
-      def params
-        attributes.compact_blank
-      end
     end
   end
 end

--- a/lib/platform_client/responses.rb
+++ b/lib/platform_client/responses.rb
@@ -7,6 +7,7 @@ require 'platform_client/responses/facilities'
 require 'platform_client/responses/properties'
 require 'platform_client/responses/property_categories'
 require 'platform_client/responses/room_categories'
+require 'platform_client/responses/rate'
 
 module PlatformClient
   # Wrapper over responses

--- a/lib/platform_client/responses/rate.rb
+++ b/lib/platform_client/responses/rate.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PlatformClient
+  module Responses
+    # Represents the response from the Kabuk Platform API for the /api/check_rate endpoint
+    class Rate < Base
+    end
+  end
+end

--- a/spec/platform_client/requests/end_point_spec.rb
+++ b/spec/platform_client/requests/end_point_spec.rb
@@ -49,5 +49,13 @@ RSpec.describe PlatformClient::Requests::EndPoint do
       expect(endpoint.method).to eq(:get)
       expect(endpoint.type).to eq(:content)
     end
+
+    it 'returns the correct endpoint for rate' do
+      endpoint = described_class.find!(:rate)
+
+      expect(endpoint.uri).to eq('/api/check_rate')
+      expect(endpoint.method).to eq(:get)
+      expect(endpoint.type).to eq(:shopping)
+    end
   end
 end

--- a/spec/platform_client/requests/rates_spec.rb
+++ b/spec/platform_client/requests/rates_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe PlatformClient::Requests::Rate, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:property_code) }
+    it { is_expected.to validate_presence_of(:room_code) }
+
+    context 'with format validations' do
+      context 'with check_in_date and check_out_date' do
+        it { is_expected.to allow_value('2025-01-01').for(:check_in_date) }
+        it { is_expected.to allow_value('2025-12-31').for(:check_out_date) }
+        it { is_expected.not_to allow_value('01-01-2025').for(:check_in_date) }
+        it { is_expected.not_to allow_value('2025/01/01').for(:check_out_date) }
+        it { is_expected.not_to allow_value(nil).for(:check_in_date) }
+      end
+
+      context 'with adults_count' do
+        it { is_expected.to allow_value(rand(1..5)).for(:adults_count) }
+        it { is_expected.not_to allow_value(6).for(:adults_count) }
+        it { is_expected.not_to allow_value(0).for(:adults_count) }
+        it { is_expected.not_to allow_value('abc').for(:adults_count) }
+      end
+    end
+  end
+end

--- a/spec/platform_client/requests_spec.rb
+++ b/spec/platform_client/requests_spec.rb
@@ -258,4 +258,23 @@ RSpec.describe PlatformClient::Requests do
       end
     end
   end
+
+  describe '.check_rate' do
+    context 'with valid parameters', vcr: { cassette_name: 'shopping/check_rate' } do
+      it 'returns the rate for the specified property room' do
+        response = described_class.check_rate(
+          property_code: 'bk60',
+          room_code: '104',
+          check_in_date: '2025-01-23',
+          check_out_date: '2025-01-25',
+          adults_count: 1
+        )
+        expect(response).to be_a PlatformClient::Responses::Rate
+
+        rate = response.data
+        expect(rate).to be_a Hash
+        expect(rate.keys).to contain_exactly('rate_key', 'net', 'available_rooms', 'board_code', 'non_refundable', 'cancellation_remarks', 'supplier_description', 'check_in_date', 'check_out_date', 'room_name', 'room_code', 'cancellation_policies', 'check_in_instructions', 'hotel_fees')
+      end
+    end
+  end
 end

--- a/spec/vcr_cassettes/shopping/check_rate.yml
+++ b/spec/vcr_cassettes/shopping/check_rate.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://kabuk-platform.com/api/check_rate?adults_count=1&check_in_date=2025-01-23&check_out_date=2025-01-25&property_code=bk60&room_code=104
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip
+      User-Agent:
+      - API Client for Kabuk Platform
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"8256c9f6aff1747da8e0a2e41ef81dcc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6cedec7d-79a2-44dd-a6d8-2c8135e44623
+      X-Runtime:
+      - '34.704603'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.18, unpermitted_parameters.action_controller;dur=0.00,
+        sql.active_record;dur=25.26, instantiation.active_record;dur=14.57, start_transaction.active_record;dur=0.00,
+        transaction.active_record;dur=34591.62, process_action.action_controller;dur=34671.46
+      Content-Length:
+      - '621'
+    body:
+      encoding: UTF-8
+      string: '{"rate_key":"3f08b683-89aa-4bde-aed2-7fec7e67b2ed","net":"10795.72","available_rooms":null,"board_code":"room_only","non_refundable":false,"cancellation_remarks":"This
+        policy is fully refundable","supplier_description":"Standard - 1 Queen Bed","check_in_date":"2025-01-23","check_out_date":"2025-01-25","room_name":"Harmony
+        Johnson I","room_code":"104","check_in_instructions":null,"hotel_fees":{"optional
+        service car":{"value":100,"currency":"USD"},"resort fee per head upon check-in":{"value":1,"currency":"USD"}},"cancellation_policies":[{"date_from":"2025-01-21","date_to":"2025-01-24","percent":0.0,"amount":"0.0"}]}'
+  recorded_at: Tue, 21 Jan 2025 13:51:27 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
### Link to spec
https://www.notion.so/kabukstyle/create-check-rate-api-wrapper-in-platform-client-182df9dd923a801aa273c5f8a30f247b

### How to use it?

```ruby
PlatformClient::Requests.check_rate(property_code: 'bk60', room_code: '104', check_in_date: '2025-01-23', check_out_date: '2025-01-25', adults_count: 1)
```