### PR TITLE
feat [KKST-170] wrapper for platform booking api 

### DIFF
--- a/lib/platform_client/requests.rb
+++ b/lib/platform_client/requests.rb
@@ -9,6 +9,7 @@ require 'platform_client/requests/facilities'
 require 'platform_client/requests/properties'
 require 'platform_client/requests/property_categories'
 require 'platform_client/requests/room_categories'
+require 'platform_client/requests/booking'
 
 module PlatformClient
   # Wrapper over requests
@@ -76,6 +77,20 @@ module PlatformClient
       # @return [PlatformClient::Responses::RoomCategories]
       def room_categories(page: nil, limit: nil)
         RoomCategories.call(page:, limit:)
+      end
+
+      # Create the booking for a room
+      #
+      # @param rate_key [String] Rate key of the room to book recieved from the +.check_rate+ endpoint
+      # @param client_reference [String] Unique Client reference for the booking
+      # @param first_name [String] First name of the guest
+      # @param last_name [String] Last name of the guest
+      # @param nationality [String] Nationality of the guest
+      # @param contact_number [String] Contact number of the guest
+      #
+      # @return [PlatformClient::Responses::Booking]
+      def create_booking(rate_key:, client_reference:, first_name:, last_name:, nationality:, contact_number:) # rubocop:disable Metrics/ParameterLists
+        Booking.call(rate_key:, client_reference:, first_name:, last_name:, nationality:, contact_number:)
       end
     end
   end

--- a/lib/platform_client/requests/base.rb
+++ b/lib/platform_client/requests/base.rb
@@ -59,7 +59,7 @@ module PlatformClient
       end
 
       def params
-        raise NotImplementedError
+        attributes.compact_blank
       end
 
       def uri_params

--- a/lib/platform_client/requests/booking.rb
+++ b/lib/platform_client/requests/booking.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module PlatformClient
+  module Requests
+    # Wrapper for the /api/bookings endpoint
+    class Booking < Base
+      attribute :rate_key, :string
+      attribute :client_reference, :string
+      attribute :first_name, :string
+      attribute :last_name, :string
+      attribute :nationality, :string
+      attribute :contact_number, :string
+
+      validates :client_reference, :first_name, :last_name, :nationality, :rate_key, :contact_number, presence: true
+      validates :nationality, format: { with: /\A[A-Z]{2}\z/, message: 'must be a valid ISO 3166-1 alpha-2 country code' }
+    end
+  end
+end

--- a/lib/platform_client/requests/end_point.rb
+++ b/lib/platform_client/requests/end_point.rb
@@ -47,6 +47,11 @@ module PlatformClient
           method: :get,
           type: :content,
         },
+        booking: {
+          uri: '/api/bookings',
+          method: :post,
+          type: :shopping,
+        },
       }.freeze
 
       class << self

--- a/lib/platform_client/responses.rb
+++ b/lib/platform_client/responses.rb
@@ -7,6 +7,7 @@ require 'platform_client/responses/facilities'
 require 'platform_client/responses/properties'
 require 'platform_client/responses/property_categories'
 require 'platform_client/responses/room_categories'
+require 'platform_client/responses/booking'
 
 module PlatformClient
   # Wrapper over responses

--- a/lib/platform_client/responses/booking.rb
+++ b/lib/platform_client/responses/booking.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PlatformClient
+  module Responses
+    # Represents the response from the Kabuk Platform API for the post /api/bookings endpoint
+    class Booking < Base
+    end
+  end
+end

--- a/spec/platform_client/requests/booking_spec.rb
+++ b/spec/platform_client/requests/booking_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe PlatformClient::Requests::Booking, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:rate_key) }
+    it { is_expected.to validate_presence_of(:client_reference) }
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:nationality) }
+    it { is_expected.to validate_presence_of(:contact_number) }
+    it { is_expected.to allow_value('US').for(:nationality) }
+
+    context 'with invalid nationality' do
+      it { is_expected.not_to allow_value('US,CA').for(:nationality) }
+      it { is_expected.not_to allow_value('us').for(:nationality) }
+      it { is_expected.not_to allow_value('USA').for(:nationality) }
+    end
+  end
+end

--- a/spec/platform_client/requests/end_point_spec.rb
+++ b/spec/platform_client/requests/end_point_spec.rb
@@ -49,5 +49,13 @@ RSpec.describe PlatformClient::Requests::EndPoint do
       expect(endpoint.method).to eq(:get)
       expect(endpoint.type).to eq(:content)
     end
+
+    it 'returns the correct endpoint for booking' do
+      endpoint = described_class.find!(:booking)
+
+      expect(endpoint.uri).to eq('/api/bookings')
+      expect(endpoint.method).to eq(:post)
+      expect(endpoint.type).to eq(:shopping)
+    end
   end
 end

--- a/spec/platform_client/requests_spec.rb
+++ b/spec/platform_client/requests_spec.rb
@@ -258,4 +258,26 @@ RSpec.describe PlatformClient::Requests do
       end
     end
   end
+
+  describe '.create_booking' do
+    context 'with valid parameters', vcr: { cassette_name: 'shopping/create_booking' } do
+      it 'returns the created booking for the specified property room with status, rate, and guest details' do
+        response = described_class.create_booking(
+          rate_key: 'db470bf0-90c5-4bf8-9a3f-dd52b0f94798',
+          first_name: 'John',
+          last_name: 'Doe',
+          client_reference: 'XYZ123',
+          contact_number: '123456',
+          nationality: 'JP'
+        )
+        expect(response).to be_a PlatformClient::Responses::Booking
+
+        booking_response = response.data
+        expect(booking_response).to be_a Hash
+        expect(booking_response.keys).to contain_exactly('client_reference', 'status', 'rate', 'guests')
+        expect(booking_response['rate'].keys).to contain_exactly('rate_key', 'net', 'available_rooms', 'board_code', 'non_refundable', 'cancellation_remarks', 'supplier_description', 'check_in_date', 'check_out_date', 'room_name', 'room_code', 'cancellation_policies', 'check_in_instructions', 'hotel_fees')
+        expect(booking_response['guests'].sample.keys).to contain_exactly('first_name', 'last_name', 'contact_number', 'nationality')
+      end
+    end
+  end
 end

--- a/spec/vcr_cassettes/shopping/create_booking.yml
+++ b/spec/vcr_cassettes/shopping/create_booking.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://kabuk-platform.com/api/bookings
+    body:
+      encoding: UTF-8
+      string: '{"rate_key":"db470bf0-90c5-4bf8-9a3f-dd52b0f94798","client_reference":"XYZ123","first_name":"John","last_name":"Doe","nationality":"JP","contact_number":"123456"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip
+      User-Agent:
+      - API Client for Kabuk Platform
+      Authorization:
+      - Bearer <BEARER_TOKEN>
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Content-Type:
+      - application/json; charset=utf-8
+      Vary:
+      - Accept
+      Etag:
+      - W/"46ebdb35c9b374b2c43b24715c83ea9a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5c53da5d-d2c0-4700-8daf-00460c636e5c
+      X-Runtime:
+      - '1.229178'
+      Server-Timing:
+      - start_processing.action_controller;dur=0.01, unpermitted_parameters.action_controller;dur=0.00,
+        sql.active_record;dur=17.61, start_transaction.active_record;dur=0.00, instantiation.active_record;dur=4.10,
+        transaction.active_record;dur=1160.79, process_action.action_controller;dur=1210.96
+      Content-Length:
+      - '773'
+    body:
+      encoding: UTF-8
+      string: '{"client_reference":"XYZ123","status":"pending","rate":{"rate_key":"db470bf0-90c5-4bf8-9a3f-dd52b0f94798","net":"10795.72","available_rooms":null,"board_code":"room_only","non_refundable":false,"cancellation_remarks":"This
+        policy is fully refundable","supplier_description":"Standard - 1 Queen Bed","check_in_date":"2025-01-24","check_out_date":"2025-01-26","room_name":"Harmony
+        Johnson I","room_code":"104","check_in_instructions":null,"hotel_fees":{"optional
+        service car":{"value":100,"currency":"USD"},"resort fee per head upon check-in":{"value":1,"currency":"USD"}},"cancellation_policies":[{"date_from":"2025-01-21","date_to":"2025-01-25","percent":0.0,"amount":"0.0"}]},"guests":[{"first_name":"John","last_name":"Doe","nationality":"JP","contact_number":"123456"}]}'
+  recorded_at: Tue, 21 Jan 2025 19:09:05 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
### Link to spec
https://www.notion.so/kabukstyle/create-bookings-api-wrapper-in-platform-client-182df9dd923a8031ba09dc2d0dc31936

### How to use it?

```ruby
PlatformClient::Requests.create_booking(rate_key: 'RATE128KW', first_name: 'John', last_name: 'Doe', client_reference: 'XYZ123', contact_number: '123456', nationality: 'JP')
```