### PR TITLE
fix: Garbled response when API returns error

### DIFF
--- a/lib/platform_client/client.rb
+++ b/lib/platform_client/client.rb
@@ -18,15 +18,15 @@ module PlatformClient
         # If the response body is not valid JSON, it will raise a Faraday::ParsingError.
         conn.response :json
 
-        # Adds the necessary Accept-Encoding headers and automatically decompresses the response.
-        conn.request :gzip
+        # Logs requests and responses.
+        # By default, it only logs the request method and URL, and the request/response headers.
+        conn.response :logger
 
         # Raises an error on 4xx and 5xx responses.
         conn.response :raise_error
 
-        # Logs requests and responses.
-        # By default, it only logs the request method and URL, and the request/response headers.
-        conn.response :logger
+        # Adds the necessary Accept-Encoding headers and automatically decompresses the response.
+        conn.request :gzip
 
         # defaults to :net_http
         conn.adapter Faraday.default_adapter


### PR DESCRIPTION
#### Problem
When API returns error response, the response body get garbled text
![Screenshot from 2025-01-31 09-30-47](https://github.com/user-attachments/assets/c93b94a7-34cf-47ed-88cf-decac4dce25c)

It adds the necessary Accept-Encoding headers and automatically decompresses the response. It would interfere with other middlewares that modify the request or response, such as setting the content type or parsing the response.

#### Root cause
The gzip middleware processe the request earlier in the middlware chain.

#### Resolution
By placing it last, it ensure that all other middlewares have already processed the request and response, and then the gzip compression is applied.

![Screenshot from 2025-01-31 09-20-00](https://github.com/user-attachments/assets/0526e77d-cc98-49b1-abab-744910ba1737)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated HTTP client configuration for improved logging and request handling.
	- Adjusted middleware setup for network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->