### PR TITLE
chore: Set client app environment header

### DIFF
--- a/lib/platform_client/configuration.rb
+++ b/lib/platform_client/configuration.rb
@@ -4,6 +4,7 @@ module PlatformClient
   # Configuration class
   class Configuration
     attr_writer :base_url
+    attr_accessor :client_app_env
 
     # The base URL for the API
     #

--- a/lib/platform_client/requests/base.rb
+++ b/lib/platform_client/requests/base.rb
@@ -70,8 +70,9 @@ module PlatformClient
         {
           'Content-Type' => 'application/json',
           'Accept-Encoding' => 'gzip',
-          'User-Agent' => 'API Client for Kabuk Platform',
-        }
+          'User-Agent' => "API Client for Kabuk Platform - #{client_app_env}",
+          'X-Client-App-Env' => client_app_env,
+        }.compact_blank
       end
 
       def response_class
@@ -83,6 +84,10 @@ module PlatformClient
       # @param base_url [String] the base URL for the request. Content and Shopping APIs have different base URL.
       def connection
         @connection ||= Client.new.connection
+      end
+
+      def client_app_env
+        PlatformClient.configuration.client_app_env
       end
     end
   end


### PR DESCRIPTION
Platform need to send back webhook. There will be only [one platform staging environment for all the HafH staging environments](https://kabukstyleinc.slack.com/archives/C053Z4GNMC4/p1739328802315919?thread_ts=1739266798.786139&cid=C053Z4GNMC4)

So need to pass the origin of the request to identify the origin of each request in order to send the webhook accordingly later.