### PR TITLE
chore: make room code optional in availability wrapper

### DIFF
--- a/lib/platform_client/requests.rb
+++ b/lib/platform_client/requests.rb
@@ -105,7 +105,7 @@ module PlatformClient
       # @param adults_count [Integer] Number of adults, default is 1
       #
       # @return [PlatformClient::Responses::Availabilities]
-      def check_availability(property_code:, room_code:, from_date:, to_date:, adults_count: 1)
+      def check_availability(property_code:, from_date:, to_date:, adults_count: 1, room_code: nil)
         Availabilities.call(property_code:, room_code:, from_date:, to_date:, adults_count:)
       end
 

--- a/lib/platform_client/requests/availabilities.rb
+++ b/lib/platform_client/requests/availabilities.rb
@@ -10,7 +10,7 @@ module PlatformClient
       attribute :to_date, :string
       attribute :adults_count, :integer
 
-      validates :property_code, :room_code, presence: true
+      validates :property_code, presence: true
       validates :from_date, :to_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be in YYYY-MM-DD format' }
       validates :adults_count, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 5 }, allow_nil: true
     end

--- a/spec/platform_client/requests/availabilities_spec.rb
+++ b/spec/platform_client/requests/availabilities_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe PlatformClient::Requests::Availabilities, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:property_code) }
-    it { is_expected.to validate_presence_of(:room_code) }
 
     context 'with format validations' do
       context 'with check_in_date and check_out_date' do


### PR DESCRIPTION
### Problem
Availability api has optional `room_code` but in wrapper it is required.

### Solution
Make it optional in wrapper implementation in the client.

