### PR TITLE
chore: remove limitation of adults count

### DIFF
--- a/lib/platform_client/requests/availabilities.rb
+++ b/lib/platform_client/requests/availabilities.rb
@@ -12,7 +12,7 @@ module PlatformClient
 
       validates :property_code, presence: true
       validates :from_date, :to_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be in YYYY-MM-DD format' }
-      validates :adults_count, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 5 }, allow_nil: true
+      validates :adults_count, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
     end
   end
 end

--- a/lib/platform_client/requests/rate.rb
+++ b/lib/platform_client/requests/rate.rb
@@ -13,7 +13,7 @@ module PlatformClient
 
       validates :property_code, :room_code, presence: true
       validates :check_in_date, :check_out_date, format: { with: /\A\d{4}-\d{2}-\d{2}\z/, message: 'must be in YYYY-MM-DD format' }
-      validates :adults_count, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 5 }, allow_nil: true
+      validates :adults_count, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
       validates :nationality, format: { with: /\A[A-Z]{2}\z/, message: 'must be a valid ISO 3166-1 alpha-2 country code' }, allow_blank: true
     end
   end

--- a/spec/platform_client/requests/availabilities_spec.rb
+++ b/spec/platform_client/requests/availabilities_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe PlatformClient::Requests::Availabilities, type: :model do
       end
 
       context 'with adults_count' do
-        it { is_expected.to allow_value(rand(1..5)).for(:adults_count) }
-        it { is_expected.not_to allow_value(6).for(:adults_count) }
+        it { is_expected.to allow_value(rand(1..10)).for(:adults_count) }
         it { is_expected.not_to allow_value(0).for(:adults_count) }
         it { is_expected.not_to allow_value('abc').for(:adults_count) }
       end

--- a/spec/platform_client/requests/rates_spec.rb
+++ b/spec/platform_client/requests/rates_spec.rb
@@ -15,8 +15,7 @@ RSpec.describe PlatformClient::Requests::Rate, type: :model do
       end
 
       context 'with adults_count' do
-        it { is_expected.to allow_value(rand(1..5)).for(:adults_count) }
-        it { is_expected.not_to allow_value(6).for(:adults_count) }
+        it { is_expected.to allow_value(rand(1..10)).for(:adults_count) }
         it { is_expected.not_to allow_value(0).for(:adults_count) }
         it { is_expected.not_to allow_value('abc').for(:adults_count) }
       end


### PR DESCRIPTION
### Problem 
Max adult count is not needed and is creating a problem for some supplier rooms.

### Solution
Remove validation for max adults count on availabilities and check rate wrappers.