### PR TITLE
chore [KKS-4756] Add structured error parsing to ClientError with backward compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    platform_client (0.1.0)
+    platform_client (0.2.0)
       activemodel (>= 7.2, < 9)
       activesupport (>= 7.2, < 9)
       faraday (~> 1.10)

--- a/lib/platform_client/errors.rb
+++ b/lib/platform_client/errors.rb
@@ -87,15 +87,22 @@ module PlatformClient
         body = response_body
         return nil if body.blank?
 
-        parsed =
-          case body
-          when String then JSON.parse(body)
-          when Hash, Array then body
-          else return nil
-          end
+        parsed = parse_body(body)
+        return nil if parsed.nil?
 
         first_error = extract_first_error(parsed)
         first_error.is_a?(Hash) && first_error.key?('code') ? first_error : nil
+      end
+
+      # Converts the response body to a parsed Ruby object.
+      # Handles String (JSON), pre-parsed Hash/Array (Faraday JSON middleware), and unknown types.
+      #
+      # @return [Hash, Array, nil]
+      def parse_body(body)
+        case body
+        when String then JSON.parse(body)
+        when Hash, Array then body
+        end
       rescue JSON::ParserError, TypeError
         nil
       end

--- a/lib/platform_client/errors.rb
+++ b/lib/platform_client/errors.rb
@@ -75,23 +75,35 @@ module PlatformClient
       # Uses memoization with defined? guard so a nil result is only computed once.
       #
       # @return [Hash, nil]
-      def parsed_error_object # rubocop:disable Metrics/MethodLength
+      def parsed_error_object
         return @parsed_error_object if defined?(@parsed_error_object)
 
+        @parsed_error_object = extract_error_object
+      end
+
+      # @return [Hash, nil]
+      def extract_error_object
         body = response_body
-        if body.blank?
-          @parsed_error_object = nil
-          return @parsed_error_object
-        end
+        return nil if body.blank?
 
         parsed = JSON.parse(body)
-        errors_array = parsed.is_a?(Hash) ? parsed['errors'] : nil
-        first_error = errors_array.is_a?(Array) ? errors_array.first : nil
-        # Only treat as structured if the first element is a Hash (new format).
-        # Legacy format has strings in the errors array — return nil for those.
-        @parsed_error_object = first_error.is_a?(Hash) ? first_error : nil
+        first_error = extract_first_error(parsed)
+        first_error.is_a?(Hash) && first_error.key?('code') ? first_error : nil
       rescue JSON::ParserError
-        @parsed_error_object = nil
+        nil
+      end
+
+      # Handles both response shapes from the Platform API:
+      #   Object format (current production): { "errors": { "code": "...", ... } }
+      #   Array format  (target):             { "errors": [{ "code": "...", ... }] }
+      #
+      # @return [Object, nil]
+      def extract_first_error(parsed)
+        errors_value = parsed.is_a?(Hash) ? parsed['errors'] : nil
+        case errors_value
+        when Array then errors_value.first
+        when Hash  then errors_value
+        end
       end
     end
 

--- a/lib/platform_client/errors.rb
+++ b/lib/platform_client/errors.rb
@@ -18,6 +18,99 @@ module PlatformClient
 
         super
       end
+
+      # Convenience accessor for the raw response body string from the original Faraday error.
+      # Avoids callers needing `e.original_error.try(:response_body)`.
+      #
+      # @return [String, nil]
+      def response_body
+        original_error.try(:response_body)
+      end
+
+      # Returns true when the API returned a structured error response (new format).
+      # Structured format: {"errors": [{"code": "...", "message": "...", ...}]}
+      # Legacy format: {"errors": ["string message"]} or any non-JSON body
+      #
+      # @return [Boolean]
+      def structured?
+        parsed_error_object.is_a?(Hash) && parsed_error_object.key?('code')
+      end
+
+      # @return [String, nil] UPPERCASE error code e.g. "RATE_UNAVAILABLE"
+      def error_code
+        parsed_error_object&.fetch('code', nil)
+      end
+
+      # @return [String, nil] Human-friendly error message from the Platform API
+      def error_message
+        parsed_error_object&.fetch('message', nil)
+      end
+
+      # @return [String, nil] Technical reason code e.g. "NO_ROOM_ONLY"
+      def error_reason
+        parsed_error_object&.fetch('reason', nil)
+      end
+
+      # @return [Hash, nil] Additional error details (may include original_error_message)
+      def error_details
+        parsed_error_object&.fetch('details', nil)
+      end
+
+      # @return [String, nil] Request ID for distributed tracing across services
+      def request_id
+        parsed_error_object&.fetch('request_id', nil)
+      end
+
+      # Returns the human-friendly Platform error message when the response is structured,
+      # otherwise falls back to the original Faraday error message.
+      #
+      # @return [String]
+      def message
+        error_message.presence || original_error.message
+      end
+
+      private
+
+      # Parses the response body and returns the first structured error object, or nil.
+      # Uses memoization with defined? guard so a nil result is only computed once.
+      #
+      # @return [Hash, nil]
+      def parsed_error_object # rubocop:disable Metrics/MethodLength
+        return @parsed_error_object if defined?(@parsed_error_object)
+
+        body = response_body
+        if body.blank?
+          @parsed_error_object = nil
+          return @parsed_error_object
+        end
+
+        parsed = JSON.parse(body)
+        errors_array = parsed.is_a?(Hash) ? parsed['errors'] : nil
+        first_error = errors_array.is_a?(Array) ? errors_array.first : nil
+        # Only treat as structured if the first element is a Hash (new format).
+        # Legacy format has strings in the errors array — return nil for those.
+        @parsed_error_object = first_error.is_a?(Hash) ? first_error : nil
+      rescue JSON::ParserError
+        @parsed_error_object = nil
+      end
     end
+
+    # Raised for validation failures (422 Unprocessable Entity)
+    class ValidationError < ClientError; end
+
+    # Raised when a requested resource is not found (404)
+    class NotFoundError < ClientError; end
+
+    # Raised when a rate is no longer available for booking
+    class RateUnavailableError < ClientError; end
+
+    # Raised when a booking (confirmation) request fails
+    class BookingError < ClientError; end
+
+    # Raised when a cancellation request fails
+    class CancellationError < ClientError; end
+
+    # Raised for unexpected server-side failures (5xx)
+    class InternalError < ClientError; end
   end
 end

--- a/lib/platform_client/errors.rb
+++ b/lib/platform_client/errors.rb
@@ -19,10 +19,11 @@ module PlatformClient
         super
       end
 
-      # Convenience accessor for the raw response body string from the original Faraday error.
-      # Avoids callers needing `e.original_error.try(:response_body)`.
+      # Convenience accessor for the response body from the original Faraday error.
+      # May be a String (raw JSON), Hash, or Array when Faraday's JSON middleware has
+      # already parsed the body. Avoids callers needing `e.original_error.try(:response_body)`.
       #
-      # @return [String, nil]
+      # @return [String, Hash, Array, nil]
       def response_body
         original_error.try(:response_body)
       end
@@ -86,10 +87,16 @@ module PlatformClient
         body = response_body
         return nil if body.blank?
 
-        parsed = JSON.parse(body)
+        parsed =
+          case body
+          when String then JSON.parse(body)
+          when Hash, Array then body
+          else return nil
+          end
+
         first_error = extract_first_error(parsed)
         first_error.is_a?(Hash) && first_error.key?('code') ? first_error : nil
-      rescue JSON::ParserError
+      rescue JSON::ParserError, TypeError
         nil
       end
 

--- a/lib/platform_client/requests/base.rb
+++ b/lib/platform_client/requests/base.rb
@@ -30,9 +30,8 @@ module PlatformClient
 
         # Build the response object
         response_class.new(response)
-      rescue Faraday::ClientError => e # Handle 4xx errors from PlatformClient
-        # TODO: For now just wrap the Faraday client error and re-raise it. Later we can handle specific errors.
-        raise PlatformClient::Errors::ClientError, e
+      rescue Faraday::ClientError, Faraday::ServerError => e
+        raise build_error(e)
       end
 
       private
@@ -94,6 +93,36 @@ module PlatformClient
 
       def client_app_env
         PlatformClient.configuration.client_app_env
+      end
+
+      # Maps structured error codes returned by the Platform API to specific error subclasses.
+      ERROR_CODE_MAP = {
+        'RATE_UNAVAILABLE' => PlatformClient::Errors::RateUnavailableError,
+        'BOOKING_ERROR' => PlatformClient::Errors::BookingError,
+        'CANCELLATION_ERROR' => PlatformClient::Errors::CancellationError,
+        'NOT_FOUND' => PlatformClient::Errors::NotFoundError,
+        'VALIDATION_ERROR' => PlatformClient::Errors::ValidationError,
+      }.freeze
+
+      # Wraps a Faraday error in the most specific PlatformClient error subclass available.
+      # When the response body is structured (new format) the error_code is used for routing.
+      # When the response body is legacy / non-JSON, the base ClientError is raised so that
+      # all existing rescue clauses continue to work.
+      #
+      # @param faraday_error [Faraday::Error]
+      # @return [PlatformClient::Errors::ClientError]
+      def build_error(faraday_error)
+        return PlatformClient::Errors::InternalError.new(faraday_error) if faraday_error.is_a?(Faraday::ServerError)
+
+        error = PlatformClient::Errors::ClientError.new(faraday_error)
+        structured_error_for(error) || error
+      end
+
+      def structured_error_for(error)
+        return unless error.structured?
+
+        klass = ERROR_CODE_MAP[error.error_code]
+        klass&.new(error.original_error)
       end
     end
   end

--- a/lib/platform_client/requests/base.rb
+++ b/lib/platform_client/requests/base.rb
@@ -30,7 +30,7 @@ module PlatformClient
 
         # Build the response object
         response_class.new(response)
-      rescue Faraday::ClientError, Faraday::ServerError => e
+      rescue Faraday::ClientError, Faraday::ServerError, Faraday::ParsingError => e
         raise build_error(e)
       end
 
@@ -108,11 +108,13 @@ module PlatformClient
       # When the response body is structured (new format) the error_code is used for routing.
       # When the response body is legacy / non-JSON, the base ClientError is raised so that
       # all existing rescue clauses continue to work.
+      # Faraday::ServerError (5xx) and Faraday::ParsingError are always wrapped as InternalError.
       #
       # @param faraday_error [Faraday::Error]
       # @return [PlatformClient::Errors::ClientError]
       def build_error(faraday_error)
         return PlatformClient::Errors::InternalError.new(faraday_error) if faraday_error.is_a?(Faraday::ServerError)
+        return PlatformClient::Errors::InternalError.new(faraday_error) if faraday_error.is_a?(Faraday::ParsingError)
 
         error = PlatformClient::Errors::ClientError.new(faraday_error)
         structured_error_for(error) || error

--- a/lib/platform_client/version.rb
+++ b/lib/platform_client/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PlatformClient
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/platform_client/errors_spec.rb
+++ b/spec/platform_client/errors_spec.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/SpecFilePathFormat
+  # Helpers to build a Faraday-like error double with a given response body
+  def faraday_error_with_body(body)
+    instance_double(Faraday::ResourceNotFound, response_body: body, message: 'the server responded with status 404')
+  end
+
+  def described_error(body)
+    described_class.new(faraday_error_with_body(body))
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Structured (new) format body
+  # ─────────────────────────────────────────────────────────────────────────────
+  let(:structured_body) do
+    {
+      errors: [
+        {
+          code: 'RATE_UNAVAILABLE',
+          message: 'No packages with a friendly cancellation policy are found.',
+          reason: 'NO_FRIENDLY_CANCEL',
+          details: {
+            original_error_message: 'No refundable rates found',
+            search_criteria: { property_code: 'P123', room_code: 'R456' },
+          },
+          request_id: 'req_abc-123-xyz',
+        }
+      ],
+    }.to_json
+  end
+
+  # Legacy format — errors array contains plain strings
+  let(:legacy_body) { { errors: ['Rate is unavailable for the requested parameters.'] }.to_json }
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #response_body
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe '#response_body' do
+    it 'delegates to the original_error' do
+      expect(described_error(structured_body).response_body).to eq(structured_body)
+    end
+
+    it 'returns nil when original_error does not respond to response_body' do
+      faraday_err = instance_double(Faraday::ResourceNotFound)
+      allow(faraday_err).to receive(:try).with(:response_body).and_return(nil)
+      expect(described_class.new(faraday_err).response_body).to be_nil
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #structured?
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe '#structured?' do
+    context 'with structured error body (new format)' do
+      it 'returns true' do
+        expect(described_error(structured_body)).to be_structured
+      end
+    end
+
+    context 'with legacy string-array error body (old format)' do
+      it 'returns false' do
+        expect(described_error(legacy_body)).not_to be_structured
+      end
+    end
+
+    context 'with an HTML body (e.g. nginx error page)' do
+      it 'returns false' do
+        expect(described_error('<html><body>502 Bad Gateway</body></html>')).not_to be_structured
+      end
+    end
+
+    context 'with a nil body' do
+      it 'returns false' do
+        expect(described_error(nil)).not_to be_structured
+      end
+    end
+
+    context 'with an empty string body' do
+      it 'returns false' do
+        expect(described_error('')).not_to be_structured
+      end
+    end
+
+    context 'with malformed JSON body' do
+      it 'returns false' do
+        expect(described_error('{invalid_json')).not_to be_structured
+      end
+    end
+
+    context 'with a JSON body that has errors as non-array' do
+      it 'returns false' do
+        expect(described_error({ errors: 'plain string' }.to_json)).not_to be_structured
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Structured error accessors — new format
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe 'structured error accessors' do
+    subject(:error) { described_error(structured_body) }
+
+    describe '#error_code' do
+      it 'returns the code from the first error object' do
+        expect(error.error_code).to eq('RATE_UNAVAILABLE')
+      end
+    end
+
+    describe '#error_message' do
+      it 'returns the message from the first error object' do
+        expect(error.error_message).to eq('No packages with a friendly cancellation policy are found.')
+      end
+    end
+
+    describe '#error_reason' do
+      it 'returns the reason from the first error object' do
+        expect(error.error_reason).to eq('NO_FRIENDLY_CANCEL')
+      end
+    end
+
+    describe '#error_details' do
+      it 'returns the details hash from the first error object' do
+        expect(error.error_details).to eq(
+          'original_error_message' => 'No refundable rates found',
+          'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' }
+        )
+      end
+    end
+
+    describe '#request_id' do
+      it 'returns the request_id from the first error object' do
+        expect(error.request_id).to eq('req_abc-123-xyz')
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Structured error accessors — old / nil format (return nil gracefully)
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe 'structured error accessors with non-structured body' do
+    subject(:error) { described_error(legacy_body) }
+
+    it 'returns nil for error_code'    do expect(error.error_code).to be_nil end
+    it 'returns nil for error_message' do expect(error.error_message).to be_nil end
+    it 'returns nil for error_reason'  do expect(error.error_reason).to be_nil end
+    it 'returns nil for error_details' do expect(error.error_details).to be_nil end
+    it 'returns nil for request_id'    do expect(error.request_id).to be_nil end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # #message override
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe '#message' do
+    context 'when the body is structured' do
+      it 'returns the human-friendly error_message from the Platform API' do
+        expect(described_error(structured_body).message).to eq(
+          'No packages with a friendly cancellation policy are found.'
+        )
+      end
+    end
+
+    context 'when the body is legacy format' do
+      it 'falls back to the original Faraday error message' do
+        expect(described_error(legacy_body).message).to eq('the server responded with status 404')
+      end
+    end
+
+    context 'when the body is nil' do
+      it 'falls back to the original Faraday error message' do
+        expect(described_error(nil).message).to eq('the server responded with status 404')
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Memoization — parsed_error_object computed only once
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe 'memoization' do
+    it 'parses the response body only once per error instance' do
+      error = described_error(structured_body)
+
+      allow(JSON).to receive(:parse).once.and_call_original
+
+      error.error_code
+      error.error_message
+      error.error_reason
+      error.structured?
+
+      expect(JSON).to have_received(:parse).once
+    end
+  end
+end

--- a/spec/platform_client/errors_spec.rb
+++ b/spec/platform_client/errors_spec.rb
@@ -336,12 +336,14 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
     it 'does not call JSON.parse when body is already a Hash (pre-parsed by Faraday)' do
       error = described_error(structured_body_pre_parsed_array)
 
-      expect(JSON).not_to receive(:parse)
+      allow(JSON).to receive(:parse).and_call_original
 
       error.error_code
       error.error_message
       error.error_reason
       error.structured?
+
+      expect(JSON).not_to have_received(:parse)
     end
   end
 end

--- a/spec/platform_client/errors_spec.rb
+++ b/spec/platform_client/errors_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Structured (new) format body
+  # Structured (new) format body — errors as Array
   # ─────────────────────────────────────────────────────────────────────────────
   let(:structured_body) do
     {
@@ -27,6 +27,22 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
           request_id: 'req_abc-123-xyz',
         }
       ],
+    }.to_json
+  end
+
+  # Production format — errors as a Hash object (not wrapped in an array)
+  let(:structured_body_hash_format) do
+    {
+      errors: {
+        code: 'RATE_UNAVAILABLE',
+        message: 'No packages with a friendly cancellation policy are found.',
+        reason: 'NO_FRIENDLY_CANCEL',
+        details: {
+          original_error_message: 'No refundable rates found',
+          search_criteria: { property_code: 'P123', room_code: 'R456' },
+        },
+        request_id: 'req_abc-123-xyz',
+      },
     }.to_json
   end
 
@@ -52,9 +68,15 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   # #structured?
   # ─────────────────────────────────────────────────────────────────────────────
   describe '#structured?' do
-    context 'with structured error body (new format)' do
+    context 'with structured error body — errors as Array (new format)' do
       it 'returns true' do
         expect(described_error(structured_body)).to be_structured
+      end
+    end
+
+    context 'with structured error body — errors as Hash (current production format)' do
+      it 'returns true' do
+        expect(described_error(structured_body_hash_format)).to be_structured
       end
     end
 
@@ -96,9 +118,9 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Structured error accessors — new format
+  # Structured error accessors — errors as Array (new format)
   # ─────────────────────────────────────────────────────────────────────────────
-  describe 'structured error accessors' do
+  describe 'structured error accessors (Array format)' do
     subject(:error) { described_error(structured_body) }
 
     describe '#error_code' do
@@ -132,6 +154,25 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
       it 'returns the request_id from the first error object' do
         expect(error.request_id).to eq('req_abc-123-xyz')
       end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Structured error accessors — errors as Hash (current production format)
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe 'structured error accessors (Hash format)' do
+    subject(:error) { described_error(structured_body_hash_format) }
+
+    it 'returns the error_code'    do expect(error.error_code).to eq('RATE_UNAVAILABLE') end
+    it 'returns the error_message' do expect(error.error_message).to eq('No packages with a friendly cancellation policy are found.') end
+    it 'returns the error_reason'  do expect(error.error_reason).to eq('NO_FRIENDLY_CANCEL') end
+    it 'returns the request_id'    do expect(error.request_id).to eq('req_abc-123-xyz') end
+
+    it 'returns the error_details hash' do
+      expect(error.error_details).to eq(
+        'original_error_message' => 'No refundable rates found',
+        'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' }
+      )
     end
   end
 

--- a/spec/platform_client/errors_spec.rb
+++ b/spec/platform_client/errors_spec.rb
@@ -49,6 +49,40 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   # Legacy format — errors array contains plain strings
   let(:legacy_body) { { errors: ['Rate is unavailable for the requested parameters.'] }.to_json }
 
+  # Pre-parsed format — when Faraday JSON middleware has already parsed the body (Array format)
+  let(:structured_body_pre_parsed_array) do
+    {
+      'errors' => [
+        {
+          'code' => 'RATE_UNAVAILABLE',
+          'message' => 'No packages with a friendly cancellation policy are found.',
+          'reason' => 'NO_FRIENDLY_CANCEL',
+          'details' => {
+            'original_error_message' => 'No refundable rates found',
+            'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' },
+          },
+          'request_id' => 'req_abc-123-xyz',
+        }
+      ],
+    }
+  end
+
+  # Pre-parsed format — errors as Hash (current production, already parsed by Faraday)
+  let(:structured_body_pre_parsed_hash) do
+    {
+      'errors' => {
+        'code' => 'RATE_UNAVAILABLE',
+        'message' => 'No packages with a friendly cancellation policy are found.',
+        'reason' => 'NO_FRIENDLY_CANCEL',
+        'details' => {
+          'original_error_message' => 'No refundable rates found',
+          'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' },
+        },
+        'request_id' => 'req_abc-123-xyz',
+      },
+    }
+  end
+
   # ─────────────────────────────────────────────────────────────────────────────
   # #response_body
   # ─────────────────────────────────────────────────────────────────────────────
@@ -115,6 +149,18 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
         expect(described_error({ errors: 'plain string' }.to_json)).not_to be_structured
       end
     end
+
+    context 'with a pre-parsed Hash body — errors as Array (Faraday JSON middleware)' do
+      it 'returns true' do
+        expect(described_error(structured_body_pre_parsed_array)).to be_structured
+      end
+    end
+
+    context 'with a pre-parsed Hash body — errors as Hash (Faraday JSON middleware)' do
+      it 'returns true' do
+        expect(described_error(structured_body_pre_parsed_hash)).to be_structured
+      end
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
@@ -177,6 +223,62 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   end
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Structured error accessors — pre-parsed Hash body (Faraday JSON middleware)
+  # ─────────────────────────────────────────────────────────────────────────────
+  describe 'structured error accessors (pre-parsed Hash body — Array format)' do
+    subject(:error) { described_error(structured_body_pre_parsed_array) }
+
+    describe '#error_code' do
+      it 'returns the code from the first error object' do
+        expect(error.error_code).to eq('RATE_UNAVAILABLE')
+      end
+    end
+
+    describe '#error_message' do
+      it 'returns the message from the first error object' do
+        expect(error.error_message).to eq('No packages with a friendly cancellation policy are found.')
+      end
+    end
+
+    describe '#error_reason' do
+      it 'returns the reason from the first error object' do
+        expect(error.error_reason).to eq('NO_FRIENDLY_CANCEL')
+      end
+    end
+
+    describe '#error_details' do
+      it 'returns the details hash from the first error object' do
+        expect(error.error_details).to eq(
+          'original_error_message' => 'No refundable rates found',
+          'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' }
+        )
+      end
+    end
+
+    describe '#request_id' do
+      it 'returns the request_id from the first error object' do
+        expect(error.request_id).to eq('req_abc-123-xyz')
+      end
+    end
+  end
+
+  describe 'structured error accessors (pre-parsed Hash body — Hash format)' do
+    subject(:error) { described_error(structured_body_pre_parsed_hash) }
+
+    it 'returns the error_code'    do expect(error.error_code).to eq('RATE_UNAVAILABLE') end
+    it 'returns the error_message' do expect(error.error_message).to eq('No packages with a friendly cancellation policy are found.') end
+    it 'returns the error_reason'  do expect(error.error_reason).to eq('NO_FRIENDLY_CANCEL') end
+    it 'returns the request_id'    do expect(error.request_id).to eq('req_abc-123-xyz') end
+
+    it 'returns the error_details hash' do
+      expect(error.error_details).to eq(
+        'original_error_message' => 'No refundable rates found',
+        'search_criteria' => { 'property_code' => 'P123', 'room_code' => 'R456' }
+      )
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Structured error accessors — old / nil format (return nil gracefully)
   # ─────────────────────────────────────────────────────────────────────────────
   describe 'structured error accessors with non-structured body' do
@@ -218,7 +320,7 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
   # Memoization — parsed_error_object computed only once
   # ─────────────────────────────────────────────────────────────────────────────
   describe 'memoization' do
-    it 'parses the response body only once per error instance' do
+    it 'parses the response body only once per error instance (String body)' do
       error = described_error(structured_body)
 
       allow(JSON).to receive(:parse).once.and_call_original
@@ -229,6 +331,17 @@ RSpec.describe PlatformClient::Errors::ClientError do # rubocop:disable RSpec/Sp
       error.structured?
 
       expect(JSON).to have_received(:parse).once
+    end
+
+    it 'does not call JSON.parse when body is already a Hash (pre-parsed by Faraday)' do
+      error = described_error(structured_body_pre_parsed_array)
+
+      expect(JSON).not_to receive(:parse)
+
+      error.error_code
+      error.error_message
+      error.error_reason
+      error.structured?
     end
   end
 end

--- a/spec/platform_client/requests/base_spec.rb
+++ b/spec/platform_client/requests/base_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe PlatformClient::Requests::Base do
     { errors: { code: code, message: 'error', reason: 'REASON', details: {}, request_id: 'req_1' } }.to_json
   end
 
+  # Pre-parsed Array format — as returned by Faraday JSON middleware
+  def structured_body_pre_parsed(code)
+    { 'errors' => [{ 'code' => code, 'message' => 'error', 'reason' => 'REASON', 'details' => {}, 'request_id' => 'req_1' }] }
+  end
+
+  # Pre-parsed Hash format — as returned by Faraday JSON middleware (current production shape)
+  def structured_body_pre_parsed_hash_format(code)
+    { 'errors' => { 'code' => code, 'message' => 'error', 'reason' => 'REASON', 'details' => {}, 'request_id' => 'req_1' } }
+  end
+
   # ── 5xx → InternalError regardless of body ──────────────────────────────────
   describe 'server errors (5xx)' do
     it 'raises InternalError for a Faraday::ServerError with structured body' do
@@ -50,6 +60,19 @@ RSpec.describe PlatformClient::Requests::Base do
 
     it 'InternalError is a ClientError (backward compatible)' do
       expect(base.build_error(faraday_server_error)).to be_a(PlatformClient::Errors::ClientError)
+    end
+  end
+
+  # ── Faraday::ParsingError → InternalError ────────────────────────────────────────────
+  describe 'parsing errors (invalid JSON from proxy / middleware)' do
+    let(:parsing_error) { Faraday::ParsingError.new('unexpected token at \'invalid json\'') }
+
+    it 'wraps Faraday::ParsingError as InternalError' do
+      expect(base.build_error(parsing_error)).to be_a(PlatformClient::Errors::InternalError)
+    end
+
+    it 'InternalError is a ClientError (backward compatible)' do
+      expect(base.build_error(parsing_error)).to be_a(PlatformClient::Errors::ClientError)
     end
   end
 
@@ -114,6 +137,31 @@ RSpec.describe PlatformClient::Requests::Base do
 
     it 'returns a plain ClientError for an HTML body' do
       result = base.build_error(faraday_client_error('<html>502</html>'))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+  end
+  # ── 4xx structured (pre-parsed Hash) → specific subclass (Faraday JSON middleware) ───────
+  describe 'client errors (4xx) with pre-parsed Hash body (Faraday JSON middleware)' do
+    {
+      'RATE_UNAVAILABLE' => PlatformClient::Errors::RateUnavailableError,
+      'BOOKING_ERROR' => PlatformClient::Errors::BookingError,
+      'CANCELLATION_ERROR' => PlatformClient::Errors::CancellationError,
+      'NOT_FOUND' => PlatformClient::Errors::NotFoundError,
+      'VALIDATION_ERROR' => PlatformClient::Errors::ValidationError,
+    }.each do |code, klass|
+      it "routes '#{code}' to #{klass.name.split('::').last} (Array format, pre-parsed)" do
+        result = base.build_error(faraday_client_error(structured_body_pre_parsed(code)))
+        expect(result).to be_a(klass)
+      end
+
+      it "routes '#{code}' to #{klass.name.split('::').last} (Hash format, pre-parsed)" do
+        result = base.build_error(faraday_client_error(structured_body_pre_parsed_hash_format(code)))
+        expect(result).to be_a(klass)
+      end
+    end
+
+    it 'falls back to ClientError for an unknown structured error_code' do
+      result = base.build_error(faraday_client_error(structured_body_pre_parsed('UNKNOWN_CODE')))
       expect(result.class).to eq(PlatformClient::Errors::ClientError)
     end
   end

--- a/spec/platform_client/requests/base_spec.rb
+++ b/spec/platform_client/requests/base_spec.rb
@@ -140,6 +140,7 @@ RSpec.describe PlatformClient::Requests::Base do
       expect(result.class).to eq(PlatformClient::Errors::ClientError)
     end
   end
+
   # ── 4xx structured (pre-parsed Hash) → specific subclass (Faraday JSON middleware) ───────
   describe 'client errors (4xx) with pre-parsed Hash body (Faraday JSON middleware)' do
     {

--- a/spec/platform_client/requests/base_spec.rb
+++ b/spec/platform_client/requests/base_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Tests for the error-routing logic in PlatformClient::Requests::Base#build_error.
+# We exercise it via a minimal concrete subclass so we don't need a real HTTP stack.
+RSpec.describe PlatformClient::Requests::Base do
+  # ── Minimal concrete subclass ────────────────────────────────────────────────
+  subject(:base) { test_class.new }
+
+  let(:test_class) do
+    Class.new(described_class) do
+      # Expose build_error as a public method for direct testing
+      public :build_error
+    end
+  end
+  let(:legacy_body) { { errors: ['Something went wrong'] }.to_json }
+
+  # ── Helpers ──────────────────────────────────────────────────────────────────
+  def faraday_client_error(body)
+    instance_double(Faraday::ResourceNotFound,
+      response_body: body,
+      message: 'the server responded with status 404')
+  end
+
+  def faraday_server_error(body = nil)
+    err = Faraday::ServerError.new('the server responded with status 500')
+    allow(err).to receive(:response_body).and_return(body)
+    err
+  end
+
+  def structured_body(code)
+    { errors: [{ code: code, message: 'error', reason: 'REASON', details: {}, request_id: 'req_1' }] }.to_json
+  end
+
+  # ── 5xx → InternalError regardless of body ──────────────────────────────────
+  describe 'server errors (5xx)' do
+    it 'raises InternalError for a Faraday::ServerError with structured body' do
+      expect(base.build_error(faraday_server_error(structured_body('SOME_CODE'))))
+        .to be_a(PlatformClient::Errors::InternalError)
+    end
+
+    it 'raises InternalError for a Faraday::ServerError with a nil body' do
+      expect(base.build_error(faraday_server_error(nil)))
+        .to be_a(PlatformClient::Errors::InternalError)
+    end
+
+    it 'InternalError is a ClientError (backward compatible)' do
+      expect(base.build_error(faraday_server_error)).to be_a(PlatformClient::Errors::ClientError)
+    end
+  end
+
+  # ── 4xx structured → specific subclass ──────────────────────────────────────
+  describe 'client errors (4xx) with structured body' do
+    {
+      'RATE_UNAVAILABLE' => PlatformClient::Errors::RateUnavailableError,
+      'BOOKING_ERROR' => PlatformClient::Errors::BookingError,
+      'CANCELLATION_ERROR' => PlatformClient::Errors::CancellationError,
+      'NOT_FOUND' => PlatformClient::Errors::NotFoundError,
+      'VALIDATION_ERROR' => PlatformClient::Errors::ValidationError,
+    }.each do |code, klass|
+      it "routes error_code '#{code}' to #{klass.name.split('::').last}" do
+        result = base.build_error(faraday_client_error(structured_body(code)))
+        expect(result).to be_a(klass)
+      end
+
+      it "#{klass.name.split('::').last} is a ClientError (backward compatible)" do
+        result = base.build_error(faraday_client_error(structured_body(code)))
+        expect(result).to be_a(PlatformClient::Errors::ClientError)
+      end
+    end
+
+    it 'falls back to ClientError for an unknown structured error_code' do
+      result = base.build_error(faraday_client_error(structured_body('UNKNOWN_CODE')))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+  end
+
+  # ── 4xx legacy / non-JSON → base ClientError ────────────────────────────────
+  describe 'client errors (4xx) with non-structured body' do
+    it 'returns a plain ClientError for legacy string-array body' do
+      result = base.build_error(faraday_client_error(legacy_body))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+
+    it 'returns a plain ClientError for a nil body' do
+      result = base.build_error(faraday_client_error(nil))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+
+    it 'returns a plain ClientError for an HTML body' do
+      result = base.build_error(faraday_client_error('<html>502</html>'))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+  end
+end

--- a/spec/platform_client/requests/base_spec.rb
+++ b/spec/platform_client/requests/base_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe PlatformClient::Requests::Base do
     { errors: [{ code: code, message: 'error', reason: 'REASON', details: {}, request_id: 'req_1' }] }.to_json
   end
 
+  # Current production format — errors as a Hash rather than an Array
+  def structured_body_hash_format(code)
+    { errors: { code: code, message: 'error', reason: 'REASON', details: {}, request_id: 'req_1' } }.to_json
+  end
+
   # ── 5xx → InternalError regardless of body ──────────────────────────────────
   describe 'server errors (5xx)' do
     it 'raises InternalError for a Faraday::ServerError with structured body' do
@@ -48,8 +53,8 @@ RSpec.describe PlatformClient::Requests::Base do
     end
   end
 
-  # ── 4xx structured → specific subclass ──────────────────────────────────────
-  describe 'client errors (4xx) with structured body' do
+  # ── 4xx structured → specific subclass (Array format) ───────────────────────
+  describe 'client errors (4xx) with structured body (Array format)' do
     {
       'RATE_UNAVAILABLE' => PlatformClient::Errors::RateUnavailableError,
       'BOOKING_ERROR' => PlatformClient::Errors::BookingError,
@@ -70,6 +75,27 @@ RSpec.describe PlatformClient::Requests::Base do
 
     it 'falls back to ClientError for an unknown structured error_code' do
       result = base.build_error(faraday_client_error(structured_body('UNKNOWN_CODE')))
+      expect(result.class).to eq(PlatformClient::Errors::ClientError)
+    end
+  end
+
+  # ── 4xx structured → specific subclass (Hash format / current production) ───
+  describe 'client errors (4xx) with structured body (Hash format)' do
+    {
+      'RATE_UNAVAILABLE' => PlatformClient::Errors::RateUnavailableError,
+      'BOOKING_ERROR' => PlatformClient::Errors::BookingError,
+      'CANCELLATION_ERROR' => PlatformClient::Errors::CancellationError,
+      'NOT_FOUND' => PlatformClient::Errors::NotFoundError,
+      'VALIDATION_ERROR' => PlatformClient::Errors::ValidationError,
+    }.each do |code, klass|
+      it "routes error_code '#{code}' to #{klass.name.split('::').last}" do
+        result = base.build_error(faraday_client_error(structured_body_hash_format(code)))
+        expect(result).to be_a(klass)
+      end
+    end
+
+    it 'falls back to ClientError for an unknown structured error_code' do
+      result = base.build_error(faraday_client_error(structured_body_hash_format('UNKNOWN_CODE')))
       expect(result.class).to eq(PlatformClient::Errors::ClientError)
     end
   end

--- a/spec/platform_client/requests_spec.rb
+++ b/spec/platform_client/requests_spec.rb
@@ -398,7 +398,7 @@ RSpec.describe PlatformClient::Requests do
             adults_count: 1,
             nationality: 'US',
             country_code: 'FR',
-            customer_session_id: '019782fd-78a1-75b4-bd09-905a0b07bfd0',
+            customer_session_id: '019782fd-78a1-75b4-bd09-905a0b07bfd0'
           )
           expect(response).to be_a PlatformClient::Responses::Rate
           expect(response.customer_session_id).to eq '019782fd-78a1-75b4-bd09-905a0b07bfd0'
@@ -447,7 +447,7 @@ RSpec.describe PlatformClient::Requests do
           nationality: 'JP',
           email: 'john@example.com',
           guest_ip: '49.36.67.203',
-          customer_session_id: '019782f9-34bd-7f74-bc39-d2d6a338dc86',
+          customer_session_id: '019782f9-34bd-7f74-bc39-d2d6a338dc86'
         )
         expect(response).to be_a PlatformClient::Responses::Booking::Confirmation
         expect(response.customer_session_id).to eq '019782f9-34bd-7f74-bc39-d2d6a338dc86'


### PR DESCRIPTION
The Kabuk [Platform API has been updated to implement a standardized error handling format](https://github.com/kabuk-style/kabuk-platform/pull/398)(`**Release pending**`). All error responses will follow a structured contract instead of inconsistent string arrays or plain messages.

### New Error Response Format

Error responses are now structured JSON objects with the following fields:

- **`code`**: UPPERCASE error code (e.g., `"VALIDATION_ERROR"`, `"INTERNAL_ERROR"`)
- **`message`**: User-friendly error message suitable for display
- **`reason`**: Technical reason for the error (for logging/debugging)
- **`details`**: Additional debug information, including `original_error_message` (always included for internal API usage)
- **`request_id`**: Unique request identifier for tracing across services

### Example Error Response

```json
{
  "error": {
    "code": "VALIDATION_ERROR",
    "message": "Invalid booking parameters",
    "reason": "Missing required field: check_in_date",
    "details": {
      "original_error_message": "Validation failed: check_in_date can't be blank",
      "field": "check_in_date",
      "validation": "presence"
    },
    "request_id": "req_1234567890"
  }
}
```

:point_right: This change is done to support backward compatibility with existing error structure as well as new error structure proposed above(platform release pending)